### PR TITLE
Create SlopeDropper.ts

### DIFF
--- a/src/shared/items/1/walkaslope/SlopeDropper.ts
+++ b/src/shared/items/1/walkaslope/SlopeDropper.ts
@@ -1,1 +1,19 @@
+import Difficulty from "@antivivi/jjt-difficulties";
+import CurrencyBundle from "shared/currency/CurrencyBundle";
+import Droplet from "shared/item/Droplet";
+import Dropper from "shared/item/traits/dropper/Dropper";
+import Item from "shared/item/Item";
 
+export = new Item(script.Name)
+    .setName("Slope Dropper")
+    .setDescription("Produces droplets off a slope, weeeeee")
+    .setDifficulty(Difficulty.TheFirstDifficulty)
+    .setPrice(new CurrencyBundle().set("Funds", 640e44).set("Power", 145e27), 1)
+    .setPrice(new CurrencyBundle().set("Funds", 175e45).set("Power", 250e28), 2)
+    .addPlaceableArea("BarrenIslands","SkyPavillion")
+
+    .trait(Dropper)
+    .setDroplet(Droplet.TheFirstDroplet)
+    .setDropRate(0.75)
+
+    .exit();


### PR DESCRIPTION
temp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "Slope Dropper" item — produces droplets off a slope ("Produces droplets off a slope, weeeeee").
  * Available in two price tiers with differing power costs and can be placed in BarrenIslands: SkyPavillion.
  * Trait: Dropper; uses the first-tier droplet type; drop rate set at 0.75.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->